### PR TITLE
Fix null assignment to ValueTask

### DIFF
--- a/Profile.cs
+++ b/Profile.cs
@@ -40,7 +40,7 @@ public class Profile
     }
 
     private string _groupImportInput;
-    private ValueTask<(string text, bool edited)> _groupImportObject = ValueTask.FromResult<(string text, bool edited)>((null, false));
+    private ValueTask<(string text, bool edited)> _groupImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
 
     private void DrawGroupImport()
     {
@@ -98,7 +98,7 @@ public class Profile
             if (!windowVisible)
             {
                 _groupImportInput = null;
-                _groupImportObject = null;
+                _groupImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
             }
         }
     }
@@ -198,7 +198,7 @@ public class Profile
             if (ImGui.Button("Import group"))
             {
                 _groupImportInput = "";
-                _groupImportObject = null;
+                _groupImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
             }
 
             if (popupRequested)
@@ -249,7 +249,7 @@ public class Profile
     public void FocusLost()
     {
         _groupImportInput = null;
-        _groupImportObject = null;
+        _groupImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
     }
 
     private void DrawSettingsHorizontal(RuleState state, ReAgentSettings settings)
@@ -264,7 +264,7 @@ public class Profile
             if (ImGui.TabItemButton("Import", ImGuiTabItemFlags.Trailing))
             {
                 _groupImportInput = "";
-                _groupImportObject = null;
+                _groupImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
             }
 
             for (var i = 0; i < Groups.Count; i++)

--- a/ReAgent.cs
+++ b/ReAgent.cs
@@ -58,7 +58,7 @@ public sealed class ReAgent : BaseSettingsPlugin<ReAgentSettings>
     }
 
     private string _profileImportInput = null;
-    private ValueTask<(string text, bool edited)> _profileImportObject = null;
+    private ValueTask<(string text, bool edited)> _profileImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
 
     private void DrawProfileImport()
     {
@@ -117,7 +117,7 @@ public sealed class ReAgent : BaseSettingsPlugin<ReAgentSettings>
             if (!windowVisible)
             {
                 _profileImportInput = null;
-                _profileImportObject = null;
+                _profileImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
             }
         }
     }
@@ -147,7 +147,7 @@ public sealed class ReAgent : BaseSettingsPlugin<ReAgentSettings>
             if (ImGui.TabItemButton("Import profile##import", ImGuiTabItemFlags.Trailing))
             {
                 _profileImportInput = "";
-                _profileImportObject = null;
+                _profileImportObject = ValueTask.FromResult<(string text, bool edited)>((string.Empty, false));
             }
 
             foreach (var (profileName, profile) in Settings.Profiles.OrderByDescending(x => x.Key == Settings.CurrentProfile).ThenBy(x => x.Key).ToList())


### PR DESCRIPTION
Fix errors related to assigning `null` to `ValueTask` in `Profile.cs` and `ReAgent.cs`.

* **Profile.cs**
  - Initialize `_groupImportObject` with `ValueTask.FromResult<(string text, bool edited)>((string.Empty, false))` instead of `null`.
  - Replace all instances of `null` assignment to `_groupImportObject` with `ValueTask.FromResult<(string text, bool edited)>((string.Empty, false))`.

* **ReAgent.cs**
  - Initialize `_profileImportObject` with `ValueTask.FromResult<(string text, bool edited)>((string.Empty, false))` instead of `null`.
  - Replace all instances of `null` assignment to `_profileImportObject` with `ValueTask.FromResult<(string text, bool edited)>((string.Empty, false))`.

